### PR TITLE
GDCM-744 Allow set dates null

### DIFF
--- a/src/fields/DateField.js
+++ b/src/fields/DateField.js
@@ -50,7 +50,10 @@ const DateField = ({
 
   const onFieldChange = (newValue) => {
     setFieldTouched(field.id, true)
-    setFieldValue(field.id, formatReponse(field, newValue))
+    setFieldValue(
+      field.id,
+      newValue == null ? null : formatReponse(field, newValue)
+    )
   }
 
   return render({


### PR DESCRIPTION
This change allows to clear the value of the `<DatePicker />` and `<DateTimePicker />` components marked with the `clearable` prop.

## Related PR:
- https://github.com/fullstacklabs/gdc-movilidad-api/pull/159
- https://github.com/fullstacklabs/gdc-movilidad-client/pull/155