### PR TITLE
GCDM-839 - Adds GitHub Action to generate NPM Package

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+**Issue Link**
+
+[GCDM-XXX Description](https://fullstacklabs.atlassian.net/browse/GDCM-)
+
+**Checklist:**
+[ ] I have updated the documentation accordingly.
+[ ] I have added tests to cover my changes.
+[ ] All new and existing tests passed locally.

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,48 @@
+name: Create NPM Package
+
+on:
+  release:
+    types: [created]
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run lint
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          registry-url: https://npm.pkg.github.com/
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The NPM package will be generated on every release, and the package will
be used by CD workflow.

**Issue Link**

[GCDM-839 Configure GitHub Package deployment for gdc-dform-viewer](https://fullstacklabs.atlassian.net/browse/GDCM-839)

**Checklist:**
[ ] I have updated the documentation accordingly.
[ ] I have added tests to cover my changes.
[ ] All new and existing tests passed locally.