### PR TITLE
Prevent submitting the section form with validation errors.

### DIFF
--- a/src/DForm.js
+++ b/src/DForm.js
@@ -102,6 +102,14 @@ const DForm = ({
     })
 
   const moveToNextSection = () => {
+    // We manually run validation again because under some circumstances Formik's isValid returns true but the
+    // current values don't match the validation schema.
+    // This appears to be a Formik bug, possibly related to https://github.com/formium/formik/issues/1950.
+    // See MOV-622.
+    if (!validationSchema.isValidSync(formikValues)) {
+      return;
+    }
+    
     if (currentSectionIndex < orderedSections.length - 1 && !hasSectionErrors)
       setCurrentSectionIndex(currentSectionIndex + 1)
   }
@@ -161,6 +169,14 @@ const DForm = ({
   )
 
   const submit = () => {
+    // We manually run validation again because under some circumstances Formik's isValid returns true but the
+    // current values don't match the validation schema.
+    // This appears to be a Formik bug, possibly related to https://github.com/formium/formik/issues/1950.
+    // See MOV-622.
+    if (!validationSchema.isValidSync(formikValues)) {
+      return;
+    }
+
     if (!callValidatorsProxy()) return
     const updatedAnswers = mapFormValuesToAnswers(
       formikValues,


### PR DESCRIPTION
Under some circumstances like chaging a top-level select with conditional subforms with required fields, the section's Submit button will be enabled even if not all required fields have been filled. In these cases Formik's isValid value is true but validationSchema.isValidSync(formikValues) is false.
This happens because Formik for some reason is invoking the validation callback with stale data instead of the latest one, thus wrongly setting the valid boolean.

For now we add a workaround where we manually validate the values before submitting the form/going to the next section

This appears to be a Formik bug, possibly related to https://github.com/formium/formik/issues/1950.

See MOV-622

**Issue Link**

[GCDM-XXX Description](https://fullstacklabs.atlassian.net/browse/GDCM-)

**Checklist:**
[ ] I have updated the documentation accordingly.
[ ] I have added tests to cover my changes.
[ ] All new and existing tests passed locally.
